### PR TITLE
Try to fix dumpsys command

### DIFF
--- a/rules.c
+++ b/rules.c
@@ -88,6 +88,9 @@ void suRights() {
 	sepol_allow("servicemanager", "su", "binder", "transfer");
 	sepol_allow("system_server", "su", "binder", "call");
 	sepol_allow("system_server", "su", "fd", "use");
+	sepol_allow("system_server", "su", "fifo_file", "write");
+	sepol_allow("audioserver", "su", "fd", "use");
+	sepol_allow("audioserver", "su", "fifo_file", "write");
 
 	sepol_allow("su", "servicemanager", "dir", "search");
 	sepol_allow("su", "servicemanager", "dir", "read");


### PR DESCRIPTION
The dumpsys command does not work with root.
Device: Nexus 6P Stock ROM 7.1.2-N2G47O 
![default](https://cloud.githubusercontent.com/assets/26996262/26285121/f9670394-3e7b-11e7-872c-f40610039d05.PNG)
