### PR TITLE
Let's unbreak Termux.

### DIFF
--- a/rules.c
+++ b/rules.c
@@ -181,6 +181,8 @@ void sepol_magisk_rules() {
 		sepol_allowxperm("domain", "devpts", "chr_file", "0x5400-0x54FF");
 		if (sepol_exists("untrusted_app_25_devpts"))
 			sepol_allowxperm("domain", "untrusted_app_25_devpts", "chr_file", "0x5400-0x54FF");
+		if (sepol_exists("untrusted_app_devpts"))
+			sepol_allowxperm("domain", "untrusted_app_devpts", "chr_file", "0x5400-0x54FF");
 	}
 }
 


### PR DESCRIPTION
Here's the original issue and the explanation on Termux's Github :
[Root shell doesn't recognize non-character keys #577](https://github.com/termux/termux-app/issues/577).

Long story short, Termux's context is untrusted_app and not untrusted_app_25.
