### PR TITLE
Fix cmd

### DIFF
--- a/rules.c
+++ b/rules.c
@@ -160,4 +160,20 @@ void sepol_magisk_rules() {
 
 	// Support deodexed ROM on Oreo
 	sepol_allow("zygote", "dalvikcache_data_file", "file", "execute");
+	
+	// Cmd
+	sepol_allow("system_server", "devpts", "chr_file", "read");
+	sepol_allow("system_server", "devpts", "chr_file", "write");
+	if (sepol_exists("untrusted_app_devpts")){
+		sepol_allow("system_server", "untrusted_app_devpts", "chr_file", "read");
+		sepol_allow("system_server", "untrusted_app_devpts", "chr_file", "write");
+	}
+	if (sepol_exists("untrusted_app_25_devpts")){
+		sepol_allow("system_server", "untrusted_app_25_devpts", "chr_file", "read");
+		sepol_allow("system_server", "untrusted_app_25_devpts", "chr_file", "write");
+	}
+	if (sepol_exists("untrusted_app_all_devpts")){
+		sepol_allow("system_server", "untrusted_app_all_devpts", "chr_file", "read");
+		sepol_allow("system_server", "untrusted_app_all_devpts", "chr_file", "write");
+	}
 }


### PR DESCRIPTION
Terminal apps running root shell can't use the `cmd` command.
```
angler:/ # am
cmd: Failure calling service activity: Failed transaction (2147483646)
2|angler:/ # cmd battery
cmd: Failure calling service battery: Failed transaction (2147483646)
2|angler:/ # settings
cmd: Failure calling service settings: Failed transaction (2147483646)
2|angler:/ #
```
```
avc: denied { read write } for pid=15390 comm="cmd" path="/dev/pts/1" dev="devpts" ino=4 scontext=u:r:system_server:s0 tcontext=u:object_r:untrusted_app_devpts:s0:c512,c768 tclass=chr_file permissive=0
```